### PR TITLE
Use Promise

### DIFF
--- a/src/tink/await/AsyncField.hx
+++ b/src/tink/await/AsyncField.hx
@@ -83,7 +83,7 @@ class AsyncField {
 		var catchErr = catchCall(ctx.catcher, Context.currentPos());
 		var fail = ctx.asyncReturn
 			? catchErr
-			: macro throw $i{"$type"}(e).data;
+			: macro throw e.data;
 		var result = tmp+'_result';
 		var body = macro {
 			var $result;
@@ -154,7 +154,7 @@ class AsyncField {
 							return __return(tink.core.Outcome.Failure(tink.core.Error.withData('Error', $e1)))
 					else
 						macro @:pos(e.pos)
-							throw $i{"$type"}($e1).data
+							throw $e1.data
 				;
 			case EBreak if(ctx.loop != null):
 				return macro @:pos(e.pos)
@@ -319,7 +319,7 @@ class AsyncField {
 					else
 						process(e1, ctx, function(transformed)
 							return macro @:pos(e.pos)
-								throw $i{"$type"}($transformed).data
+								throw $transformed.data
 						);
 			case ETernary(econd, eif, eelse) |
 				 EIf (econd, eif, eelse):

--- a/tests.hxml
+++ b/tests.hxml
@@ -1,4 +1,5 @@
 -lib buddy
+-lib utest
 -cp src
 -cp tests
 -main RunTests

--- a/tests.hxml
+++ b/tests.hxml
@@ -1,5 +1,4 @@
 -lib buddy
--lib utest
 -cp src
 -cp tests
 -main RunTests

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -94,7 +94,7 @@ class RunTests extends buddy.SingleSuite {
 						case Success(_): fail('Expected Failure');
 						case Failure(e):
 							Std.is(e, Error).should.be(true);
-							(e.data == 'error').should.be(true);
+							e.data.should.be('error');
 					}
 					done();
 				});
@@ -117,7 +117,7 @@ class RunTests extends buddy.SingleSuite {
 						case Success(_): fail('Expected Failure');
 						case Failure(e):
 							Std.is(e, Error).should.be(true);
-							(e.data == 'error').should.be(true);
+							e.data.should.be('error');
 					}
 					done();
 				});

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -93,8 +93,8 @@ class RunTests extends buddy.SingleSuite {
 					switch outcome {
 						case Success(_): fail('Expected Failure');
 						case Failure(e):
-							utest.Assert.isTrue(Std.is(e, Error));
-							utest.Assert.isTrue(e.data == 'error');
+							Std.is(e, Error).should.be(true);
+							(e.data == 'error').should.be(true);
 					}
 					done();
 				});
@@ -116,8 +116,8 @@ class RunTests extends buddy.SingleSuite {
 					switch outcome {
 						case Success(_): fail('Expected Failure');
 						case Failure(e):
-							utest.Assert.isTrue(Std.is(e, Error));
-							utest.Assert.isTrue(e.data == 'error');
+							Std.is(e, Error).should.be(true);
+							(e.data == 'error').should.be(true);
 					}
 					done();
 				});
@@ -163,7 +163,10 @@ class RunTests extends buddy.SingleSuite {
 					// if `waitForIt()` returns Surprise, `value` will be an Outcome
 					value.should.be(true);
 					return Noise;
-				}).handle(done);
+				}).handle(function(outcome) {
+					outcome.should.equal(Success(Noise));
+					done();
+				});
 			});
 		});
 	}

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -90,7 +90,12 @@ class RunTests extends buddy.SingleSuite {
 			
 			it('should transform exceptions', function (done) {
 				throwError().handle(function(outcome) {
-					outcome.should.equal(Failure('error'));
+					switch outcome {
+						case Success(_): fail('Expected Failure');
+						case Failure(e):
+							utest.Assert.isTrue(Std.is(e, Error));
+							utest.Assert.isTrue(e.data == 'error');
+					}
 					done();
 				});
 			});
@@ -108,7 +113,12 @@ class RunTests extends buddy.SingleSuite {
 			
 			it('should pass exceptions', function (done) {
 				passError().handle(function(outcome) {
-					outcome.should.equal(Failure('error'));
+					switch outcome {
+						case Success(_): fail('Expected Failure');
+						case Failure(e):
+							utest.Assert.isTrue(Std.is(e, Error));
+							utest.Assert.isTrue(e.data == 'error');
+					}
 					done();
 				});
 			});
@@ -146,6 +156,14 @@ class RunTests extends buddy.SingleSuite {
 					outcome.should.equal(Success(123));
 					done();
 				});
+			});
+			
+			it('should return Promise', function (done) {
+				waitForIt().next(function(value) {
+					// if `waitForIt()` returns Surprise, `value` will be an Outcome
+					value.should.be(true);
+					return Noise;
+				}).handle(done);
 			});
 		});
 	}


### PR DESCRIPTION
This makes the transformed function returns `Promise<T>` instead of `Surprise<T, Dynamic>`. Mainly because Promise has richer API, IMO. I use Promise everywhere now.

Since `Promise<T>` is essentially `Surprise<T, Error>`, that means errors thrown are wrapped in `Error` instances, and the `data` field gets extracted when the error is caught.
So if some codes throws a string, the catch block should also catch a string.  (Closes #4)
If I understand correctly, the `Error` instance will not get destructured in the throw-catch waterfall but only at the end user's catch block, (correct me if I am wrong). If that is true, the performance impact should be minimal.

Seems passing the tests.