### PR TITLE
@:await JS Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,39 @@ An @async function's return type will also be transformed. The following functio
 }
 ```
 
+## JS Promises
+
+When `@await` is used on an expression that is a JS Promise, `tink_await` will extract the `T` from `js.lib.Promise<T>` (if it is a `js.lib.Promise`) and wrap the expression in a check-type statement:
+`($expr : tink.core.Promise<T>)`.
+
+This will leverage the magic of `tink_core` to silently convert the JS promise into a tink promise.
+
+```haxe
+var secret = @:await new SecretManagerServiceClient({
+				credentials: {
+					client_email: 'test',
+					private_key: 'test'
+				}
+			}).accessSecretVersion({
+				name: 'test'
+			});
+```
+Becomes:
+```haxe
+var secret = @:await (new SecretManagerServiceClient({
+				credentials: {
+					client_email: 'test',
+					private_key: 'test'
+				}
+			}) : tink.core.Promise<ts.Tuple3<google_cloud.secret_manager.build.protos.protos.google.cloud.secretmanager.v1.IAccessSecretVersionResponse, Null<google_cloud.secret_manager.build.protos.protos.google.cloud.secretmanager.v1.IAccessSecretVersionRequest>, Null<{}>>>
+).accessSecretVersion({
+				name: 'test'
+			});
+```
+
+Try typing that 10 times quickly.
+
+
 ## Flags
 
 - `-D await_catch_none`: Unexpected exceptions are never caught.

--- a/src/tink/await/AsyncField.hx
+++ b/src/tink/await/AsyncField.hx
@@ -201,32 +201,10 @@ class AsyncField {
 				return function() return next(EFunction(name, new AsyncField(f, false).transform()).at(pos));
 			case EMeta(m, em) if (isAwait(m.name)):
 				var tmp = tmpVar();
-				return function() return process(em, ctx,
-					function(transformed:Expr) {
-                        #if (js || hxnodejs)
-						var ct = transformed.typeof()
-							.sure()
-							.toComplex();
-						var extractedParam = switch ct {
-							case TPath({name: 'Promise',
-								pack: ['js', 'lib'],
-								params: [param]}):
-								switch param {
-									case TPType(t): t;
-									default: null;
-								}
-							default: null;
-						}
-						if (extractedParam != null)
-							transformed = macro($transformed : tink.core.Promise<$extractedParam>);
-                        #end
-						return function() return
-							macro @:pos(em.pos) {
-							$transformed
-									.handle(${handler(tmp, ctx,
-										next)});
-						}
-					});
+				return function() return process(em, ctx, function(transformed)
+					return function() return macro @:pos(em.pos)
+						tink.core.Promise.lift($transformed).handle(${handler(tmp, ctx, next)})
+				);
 			case EFor(it, expr):
 				if (!hasAwait(expr)) {
 					ctx.loop = null;


### PR DESCRIPTION
This will just extract the `T` from `js.lib.Promise<T>` (if it is a `js.lib.Promise`) and wrap the expression in a check-type statement:
`($expr : tink.core.Promise<T>)`.